### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 keywords = ["ipmi", "fan"]
 description = "ipmi fan control, is a tool to control fan speed by monitoring cpu temperature"
 license = "MIT"
-homepage = "http://github.com/yinheli/ipmi-fan-control"
-repository = "http://github.com/yinheli/ipmi-fan-control"
+homepage = "https://github.com/yinheli/ipmi-fan-control"
+repository = "https://github.com/yinheli/ipmi-fan-control"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97